### PR TITLE
Fixes #5 Locked to LF version 0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM centos:centos7
 MAINTAINER Marcin Ryzycki marcin@m12.io, Przemyslaw Ozgo linux@ozgo.info
 
-ENV LOGSTASH_IP 127.0.0.1
-
 RUN \
     yum update -y && \
-    yum install -y golang git && \
+    yum install -y golang git wget && \
     yum clean all && \
     mkdir -p /opt/logstash/ssl && \
-    cd /opt && \
-    git clone git://github.com/elasticsearch/logstash-forwarder.git && \
+    mkdir -p /opt/logstash-forwarder && \
+    wget https://github.com/elasticsearch/logstash-forwarder/archive/v0.4.0.tar.gz && \
+    tar zxvf v0.4.0.tar.gz -C /opt/logstash-forwarder --strip-components=1 && \
     cd /opt/logstash-forwarder/ && \
     go build
+
+ENV LOGSTASH_IP 127.0.0.1
 
 COPY container-files /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ MAINTAINER Marcin Ryzycki marcin@m12.io, Przemyslaw Ozgo linux@ozgo.info
 RUN \
     yum update -y && \
     yum install -y golang git wget tar && \
-    yum clean all && \
     mkdir -p /opt/logstash/ssl && \
     mkdir -p /opt/logstash-forwarder && \
     wget https://github.com/elasticsearch/logstash-forwarder/archive/v0.4.0.tar.gz && \
     tar zxvf v0.4.0.tar.gz -C /opt/logstash-forwarder --strip-components=1 && \
     cd /opt/logstash-forwarder/ && \
-    go build
+    go build && \
+    yum remove -y tar wget git golang && \
+    yum clean all
 
 ENV LOGSTASH_IP 127.0.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Marcin Ryzycki marcin@m12.io, Przemyslaw Ozgo linux@ozgo.info
 
 RUN \
     yum update -y && \
-    yum install -y golang git wget && \
+    yum install -y golang git wget tar && \
     yum clean all && \
     mkdir -p /opt/logstash/ssl && \
     mkdir -p /opt/logstash-forwarder && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN \
     cd /opt && \
     git clone git://github.com/elasticsearch/logstash-forwarder.git && \
     cd /opt/logstash-forwarder/ && \
-    git checkout ISSUE-221 && \
     go build
 
 COPY container-files /

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ### Logstash-Forwarder Docker Image
 [Logstash Forwarder](https://github.com/elasticsearch/logstash-forwarder) [Docker Image](https://registry.hub.docker.com/u/million12/logstash-forwarder/) for logstash/elasticsearch logging deployments. 
-Build from official logstash-forwarder repo and switched to ISSUE-221 branch to fix ssl problem. 
+Build from official logstash-forwarder repo and locked to release `v0.4.0`.  
+Image was stripped down from not needed packages and from being ~650M now it's only ~335M 
 
 ### SSL Certificates and Log Files 
 Logstash server ssl certificates need to be placed in `/etc/logstash/ssl/` directory. 


### PR DESCRIPTION
Changes:
- Locked to v.0.4.0 of Logstash Forwarder 
- Stripped image down from ~650M to only ~335M 
